### PR TITLE
Give the Coder Space AI its own system prompt

### DIFF
--- a/__tests__/space-engine.test.ts
+++ b/__tests__/space-engine.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  SPACE_SYSTEM_PROMPT,
   SPACE_TEMPLATES,
   buildPreviewHtml,
   fileTypeFromName,
@@ -11,6 +12,15 @@ import {
   parseStreamingAIResponse,
   templateToFiles,
 } from '../lib/space-engine';
+
+describe('SPACE_SYSTEM_PROMPT', () => {
+  it('pins the output contract the parser depends on', () => {
+    expect(SPACE_SYSTEM_PROMPT).toContain('// index.html');
+    expect(SPACE_SYSTEM_PROMPT).toMatch(/COMPLETE/);
+    expect(SPACE_SYSTEM_PROMPT).toMatch(/diffs/i);
+    expect(SPACE_SYSTEM_PROMPT).toMatch(/module imports/i);
+  });
+});
 
 describe('parseFilesFromAIResponse', () => {
   it('extracts files with explicit // filename info strings', () => {

--- a/components/coder-space.tsx
+++ b/components/coder-space.tsx
@@ -21,6 +21,7 @@ import { useAIAssistant } from '@/hooks/use-ai-assistant';
 import { AIService } from '@/lib/ai-service';
 import {
   ConsoleEntry,
+  SPACE_SYSTEM_PROMPT,
   SPACE_TEMPLATES,
   buildPreviewHtml,
   fileTypeFromName,
@@ -321,7 +322,12 @@ export default function CoderSpace() {
       const content = `${trimmed}\n\nCurrent project "${projectName}" files:\n\n${fileContext}\n\n${AI_FILE_INSTRUCTION}`;
 
       const backupFiles = filesOverride ?? files;
-      const service = new AIService(settings);
+      // The Space has its own system prompt; the user's stored chat prompt
+      // (with its step-by-step narration style) stays untouched.
+      const service = new AIService({
+        ...settings,
+        systemPrompt: SPACE_SYSTEM_PROMPT,
+      });
       let response = '';
       let watchingEditor = false;
       for await (const chunk of service.sendMessageStream([

--- a/lib/space-engine.ts
+++ b/lib/space-engine.ts
@@ -126,6 +126,31 @@ export interface ConsoleEntry {
 }
 
 /**
+ * System prompt for the Coder Space AI. Overrides the chat-oriented default
+ * prompt, which encourages step-by-step narration — here the model's entire
+ * job is emitting complete, runnable files.
+ */
+export const SPACE_SYSTEM_PROMPT = `You are the coding engine of White Rabbit Coder Space: an expert front-end engineer working inside a browser workspace where the user's files run instantly in a live preview.
+
+THE ENVIRONMENT
+- Projects are plain HTML, CSS, and vanilla JavaScript. There is no build step, no npm, no bundler.
+- All files are inlined into one document for the preview: index.html plus every .css and .js file. Do not use ES module imports between local files, and do not fetch local files at runtime — everything must work when inlined into a single page.
+- Use data URIs, emoji, or generated canvas/SVG for assets. Avoid external network dependencies.
+
+OUTPUT FORMAT — follow exactly
+- Return every new or changed file COMPLETE, each in its own fenced code block whose info string is the language then the filename: \`\`\`html // index.html
+- Never output diffs, snippets, or placeholders like "rest unchanged". A block replaces that file entirely.
+- Only include files that change. Do not restate untouched files.
+- At most one short sentence before the blocks. No explanations after.
+
+QUALITY BAR
+- Code must run with zero console errors the moment it loads. Trace your logic before answering.
+- Mobile-first and responsive; readable on a 390px screen. Respect the user's existing visual style and their manual edits.
+- Accessible by default: semantic elements, labels, sufficient contrast, visible focus.
+- Small ask, small change: fix exactly what was requested and keep everything else stable. Big ask: deliver the complete working feature, not a sketch.
+- When fixing an error, find and fix the root cause, not just the symptom.`;
+
+/**
  * Parse a still-streaming AI response: complete fenced blocks plus the one
  * block that is currently open (its fence not yet closed), so the editor can
  * show code being written live.


### PR DESCRIPTION
## Summary

The Space was inheriting the chat assistant's default system prompt, which explicitly asks the model to narrate step by step and "show the development process" — the opposite of what the Space's files-only parser needs, and a real failure source on smaller models.

`SPACE_SYSTEM_PROMPT` (in `lib/space-engine.ts`) tells the model exactly what it is and what it's doing:

- **Identity**: the coding engine of a browser workspace whose files are inlined into a single live-preview document
- **Environment rules**: vanilla HTML/CSS/JS, no build step, no local ES module imports, no runtime fetches of local files, self-contained assets
- **Output contract**: complete files in ```` ```lang // filename ```` fences, no diffs or "rest unchanged" placeholders, only changed files, minimal prose
- **Quality bar**: zero console errors on load, mobile-first, accessible, small ask = small change, fix root causes when repairing errors

The override is applied per-request in the Space only — the user's stored chat prompt for the classic editor is untouched. A test pins the contract markers the parser depends on.

## Verification

- `npx tsc --noEmit` clean, 47/47 tests passing (new test pins the prompt's contract markers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DLB9LkuQiDdeG8phXB95q

---
_Generated by [Claude Code](https://claude.ai/code/session_014DLB9LkuQiDdeG8phXB95q)_