### PR TITLE
Coder Space audit round: multi-project, share links, and rough-edge fixes

### DIFF
--- a/__tests__/space-engine.test.ts
+++ b/__tests__/space-engine.test.ts
@@ -4,14 +4,80 @@
 
 import { describe, expect, it } from 'vitest';
 import {
+  MAX_PROJECTS,
   SPACE_SYSTEM_PROMPT,
   SPACE_TEMPLATES,
+  SpaceProject,
   buildPreviewHtml,
+  decodeProjectFromHash,
+  encodeProjectToHash,
   fileTypeFromName,
   parseFilesFromAIResponse,
   parseStreamingAIResponse,
   templateToFiles,
+  upsertProject,
 } from '../lib/space-engine';
+
+function makeProject(id: string, updatedAt: number): SpaceProject {
+  return {
+    id,
+    name: `project-${id}`,
+    updatedAt,
+    files: [{ name: 'index.html', content: '<h1>x</h1>', type: 'html' }],
+  };
+}
+
+describe('upsertProject', () => {
+  it('inserts new projects newest-first and updates existing in place', () => {
+    let list = upsertProject([], makeProject('a', 100));
+    list = upsertProject(list, makeProject('b', 200));
+    expect(list.map(p => p.id)).toEqual(['b', 'a']);
+
+    list = upsertProject(list, makeProject('a', 300));
+    expect(list.map(p => p.id)).toEqual(['a', 'b']);
+    expect(list).toHaveLength(2);
+  });
+
+  it('caps the list at MAX_PROJECTS, dropping the oldest', () => {
+    let list: SpaceProject[] = [];
+    for (let i = 0; i < MAX_PROJECTS + 3; i++) {
+      list = upsertProject(list, makeProject(`p${i}`, i));
+    }
+    expect(list).toHaveLength(MAX_PROJECTS);
+    expect(list[0].id).toBe(`p${MAX_PROJECTS + 2}`);
+    expect(list.some(p => p.id === 'p0')).toBe(false);
+  });
+});
+
+describe('share link encoding', () => {
+  it('round-trips a project including unicode content', async () => {
+    const files = [
+      {
+        name: 'index.html',
+        content: '<h1>héllo 🎉</h1>',
+        type: 'html' as const,
+      },
+      {
+        name: 'app.js',
+        content: 'console.log("π ≈ 3.14");',
+        type: 'js' as const,
+      },
+    ];
+
+    const encoded = await encodeProjectToHash('my ünïcode app', files);
+    const decoded = await decodeProjectFromHash(encoded);
+
+    expect(decoded).not.toBeNull();
+    expect(decoded?.name).toBe('my ünïcode app');
+    expect(decoded?.files).toEqual(files);
+  });
+
+  it('returns null for malformed input', async () => {
+    expect(await decodeProjectFromHash('garbage')).toBeNull();
+    expect(await decodeProjectFromHash('9.notreal')).toBeNull();
+    expect(await decodeProjectFromHash('')).toBeNull();
+  });
+});
 
 describe('SPACE_SYSTEM_PROMPT', () => {
   it('pins the output contract the parser depends on', () => {

--- a/components/coder-space.tsx
+++ b/components/coder-space.tsx
@@ -23,12 +23,16 @@ import {
   ConsoleEntry,
   SPACE_SYSTEM_PROMPT,
   SPACE_TEMPLATES,
+  SpaceProject,
   buildPreviewHtml,
+  decodeProjectFromHash,
+  encodeProjectToHash,
   fileTypeFromName,
   monacoLanguageFromName,
   parseFilesFromAIResponse,
   parseStreamingAIResponse,
   templateToFiles,
+  upsertProject,
 } from '@/lib/space-engine';
 import JSZip from 'jszip';
 import {
@@ -40,40 +44,66 @@ import {
   Rocket,
   Send,
   Settings,
+  Share2,
   Sparkles,
+  Square,
   Terminal,
   Undo2,
   X,
 } from 'lucide-react';
 import Link from 'next/link';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 
-const PROJECT_STORAGE_KEY = 'wr-space-project';
+const PROJECTS_STORAGE_KEY = 'wr-space-projects';
+const LEGACY_PROJECT_KEY = 'wr-space-project';
 
-interface SavedProject {
-  name: string;
-  files: Array<Pick<FileContent, 'name' | 'content' | 'type'>>;
+function newProjectId(): string {
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 7)}`;
 }
 
-function loadSavedProject(): SavedProject | null {
-  if (typeof window === 'undefined') return null;
-  const raw = localStorage.getItem(PROJECT_STORAGE_KEY);
-  if (!raw) return null;
+/** Read the project list, migrating the old single-project slot once. */
+function loadProjects(): SpaceProject[] {
+  if (typeof window === 'undefined') return [];
+  let projects: SpaceProject[] = [];
   try {
-    const parsed = JSON.parse(raw);
-    if (parsed?.name && Array.isArray(parsed.files) && parsed.files.length) {
-      return parsed;
+    const parsed = JSON.parse(
+      localStorage.getItem(PROJECTS_STORAGE_KEY) || '[]'
+    );
+    if (Array.isArray(parsed)) {
+      projects = parsed.filter(
+        p => p?.id && p?.name && Array.isArray(p.files) && p.files.length
+      );
     }
   } catch {
-    localStorage.removeItem(PROJECT_STORAGE_KEY);
+    localStorage.removeItem(PROJECTS_STORAGE_KEY);
   }
-  return null;
+  try {
+    const legacyRaw = localStorage.getItem(LEGACY_PROJECT_KEY);
+    if (legacyRaw) {
+      const legacy = JSON.parse(legacyRaw);
+      if (legacy?.name && Array.isArray(legacy.files) && legacy.files.length) {
+        projects = upsertProject(projects, {
+          id: newProjectId(),
+          name: legacy.name,
+          updatedAt: Date.now(),
+          files: legacy.files,
+        });
+        localStorage.setItem(PROJECTS_STORAGE_KEY, JSON.stringify(projects));
+      }
+      localStorage.removeItem(LEGACY_PROJECT_KEY);
+    }
+  } catch {
+    localStorage.removeItem(LEGACY_PROJECT_KEY);
+  }
+  return projects.sort((a, b) => b.updatedAt - a.updatedAt);
+}
+
+function timeAgo(timestamp: number): string {
+  const mins = Math.max(1, Math.round((Date.now() - timestamp) / 60000));
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.round(hours / 24)}d ago`;
 }
 
 const AI_FILE_INSTRUCTION =
@@ -151,11 +181,12 @@ function Celebration({ show }: { show: boolean }) {
 
 export default function CoderSpace() {
   const [stage, setStage] = useState<'launch' | 'workspace'>('launch');
+  const [projectId, setProjectId] = useState<string>('');
   const [projectName, setProjectName] = useState('untitled-space');
   const [files, setFiles] = useState<FileContent[]>([]);
   const [selectedFile, setSelectedFile] = useState<string>('');
   const [showPreview, setShowPreview] = useState(true);
-  const [hasSaved, setHasSaved] = useState(false);
+  const [projects, setProjects] = useState<SpaceProject[]>([]);
   const [prompt, setPrompt] = useState('');
   const [status, setStatus] = useState<string>('');
   const [busy, setBusy] = useState(false);
@@ -172,6 +203,7 @@ export default function CoderSpace() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const promptRef = useRef<HTMLInputElement>(null);
   const celebrateTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelRef = useRef(false);
 
   const triggerCelebration = useCallback(() => {
     if (celebrateTimer.current) clearTimeout(celebrateTimer.current);
@@ -189,18 +221,27 @@ export default function CoderSpace() {
     useAIAssistant();
 
   useEffect(() => {
-    setHasSaved(loadSavedProject() !== null);
+    setProjects(loadProjects());
   }, []);
 
-  // Autosave while in the workspace
+  // Autosave the current project into the project list
   useEffect(() => {
-    if (stage !== 'workspace' || files.length === 0) return;
-    const saved: SavedProject = {
-      name: projectName,
-      files: files.map(({ name, content, type }) => ({ name, content, type })),
-    };
-    localStorage.setItem(PROJECT_STORAGE_KEY, JSON.stringify(saved));
-  }, [stage, files, projectName]);
+    if (stage !== 'workspace' || files.length === 0 || !projectId) return;
+    setProjects(prev => {
+      const next = upsertProject(prev, {
+        id: projectId,
+        name: projectName,
+        updatedAt: Date.now(),
+        files: files.map(({ name, content, type }) => ({
+          name,
+          content,
+          type,
+        })),
+      });
+      localStorage.setItem(PROJECTS_STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, [stage, files, projectName, projectId]);
 
   // Cmd/Ctrl+K focuses the prompt from anywhere
   useEffect(() => {
@@ -228,7 +269,22 @@ export default function CoderSpace() {
     return () => window.removeEventListener('message', onMessage);
   }, []);
 
-  const previewHtml = useMemo(() => buildPreviewHtml(files), [files]);
+  // Debounce preview rebuilds so typing doesn't restart the running app on
+  // every keystroke; the first build after entering a project is immediate.
+  const [previewHtml, setPreviewHtml] = useState('');
+  useEffect(() => {
+    if (files.length === 0) return;
+    if (!previewHtml) {
+      setPreviewHtml(buildPreviewHtml(files));
+      return;
+    }
+    const timer = setTimeout(
+      () => setPreviewHtml(buildPreviewHtml(files)),
+      500
+    );
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [files]);
 
   // Each preview re-render is a fresh run; stale logs would mislead
   useEffect(() => {
@@ -238,18 +294,39 @@ export default function CoderSpace() {
   const currentFile = files.find(f => f.name === selectedFile);
 
   const enterWorkspace = useCallback(
-    (nextFiles: FileContent[], name: string, fromTemplate = 'default') => {
+    (
+      nextFiles: FileContent[],
+      name: string,
+      fromTemplate = 'default',
+      existingId?: string
+    ) => {
+      setProjectId(existingId ?? newProjectId());
       setFiles(nextFiles);
       setSelectedFile(nextFiles[0]?.name ?? '');
       setProjectName(name);
       setTemplateId(fromTemplate);
       setStage('workspace');
       setStatus('');
+      setPreviewHtml('');
       setShowHint(!localStorage.getItem(HINT_DISMISSED_KEY));
       triggerCelebration();
     },
     [triggerCelebration]
   );
+
+  // A shared project link (#p=…) opens straight into the workspace
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (!hash.startsWith('#p=')) return;
+    void decodeProjectFromHash(hash.slice(3)).then(shared => {
+      if (!shared) return;
+      window.history.replaceState(null, '', window.location.pathname);
+      enterWorkspace(
+        shared.files.map(f => ({ ...f, lastModified: new Date() })),
+        shared.name
+      );
+    });
+  }, [enterWorkspace]);
 
   const startFromTemplate = (id: string) => {
     const template = SPACE_TEMPLATES.find(t => t.id === id);
@@ -266,13 +343,40 @@ export default function CoderSpace() {
     localStorage.setItem(HINT_DISMISSED_KEY, '1');
   };
 
-  const resumeSaved = () => {
-    const saved = loadSavedProject();
-    if (!saved) return;
+  const openProject = (project: SpaceProject) => {
     enterWorkspace(
-      saved.files.map(f => ({ ...f, lastModified: new Date() })),
-      saved.name
+      project.files.map(f => ({ ...f, lastModified: new Date() })),
+      project.name,
+      'default',
+      project.id
     );
+  };
+
+  const deleteProject = (id: string) => {
+    if (!window.confirm('Delete this project?')) return;
+    setProjects(prev => {
+      const next = prev.filter(p => p.id !== id);
+      localStorage.setItem(PROJECTS_STORAGE_KEY, JSON.stringify(next));
+      return next;
+    });
+  };
+
+  const shareProject = async () => {
+    const encoded = await encodeProjectToHash(
+      projectName,
+      files.map(({ name, content, type }) => ({ name, content, type }))
+    );
+    if (encoded.length > 24000) {
+      setStatus('Project too big for a share link — use the ZIP export.');
+      return;
+    }
+    const url = `${window.location.origin}/#p=${encoded}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setStatus('Share link copied — anyone can open this project with it.');
+    } catch {
+      window.prompt('Copy your share link:', url);
+    }
   };
 
   const applyAIFiles = useCallback(
@@ -309,6 +413,7 @@ export default function CoderSpace() {
       return;
     }
     setBusy(true);
+    cancelRef.current = false;
     setStatus('Thinking…');
     setPrompt('');
     try {
@@ -338,6 +443,7 @@ export default function CoderSpace() {
           timestamp: new Date(),
         },
       ])) {
+        if (cancelRef.current) break;
         response += chunk;
         const { streaming } = parseStreamingAIResponse(response);
         if (streaming) {
@@ -523,14 +629,34 @@ export default function CoderSpace() {
             ))}
           </div>
 
-          {hasSaved && (
-            <div className='text-center'>
-              <button
-                onClick={resumeSaved}
-                className='text-sm text-[#00ffe1] hover:underline'
-              >
-                Resume your last project →
-              </button>
+          {projects.length > 0 && (
+            <div className='space-y-2'>
+              <p className='text-xs font-mono text-[#555] uppercase tracking-wider'>
+                Your projects
+              </p>
+              {projects.slice(0, 5).map(p => (
+                <div
+                  key={p.id}
+                  className='flex items-center gap-2 rounded-xl bg-[#161616] border border-[#262626] hover:border-[#6c2fff] px-4 py-2.5'
+                >
+                  <button
+                    onClick={() => openProject(p)}
+                    className='flex-1 flex items-center justify-between text-left min-w-0'
+                  >
+                    <span className='text-sm truncate'>{p.name}</span>
+                    <span className='text-xs text-[#555] font-mono shrink-0 ml-3'>
+                      {timeAgo(p.updatedAt)}
+                    </span>
+                  </button>
+                  <button
+                    onClick={() => deleteProject(p.id)}
+                    className='text-[#555] hover:text-[#ff3c75] shrink-0'
+                    aria-label={`Delete ${p.name}`}
+                  >
+                    <X className='w-3.5 h-3.5' />
+                  </button>
+                </div>
+              ))}
             </div>
           )}
 
@@ -603,6 +729,13 @@ export default function CoderSpace() {
           {consoleEntries.some(e => e.level === 'error') && (
             <span className='absolute top-0.5 right-0.5 w-1.5 h-1.5 rounded-full bg-[#ff3c75]' />
           )}
+        </button>
+        <button
+          onClick={() => void shareProject()}
+          className='p-1.5 rounded-lg hover:bg-[#161616] text-[#7a7a7a] hover:text-[#00ffe1]'
+          aria-label='Copy share link'
+        >
+          <Share2 className='w-4 h-4' />
         </button>
         <button
           onClick={exportZip}
@@ -715,6 +848,15 @@ export default function CoderSpace() {
       {/* Console panel */}
       {consoleOpen && (
         <div className='shrink-0 border-t border-[#262626] bg-[#0a0a0a] max-h-36 overflow-y-auto font-mono text-xs'>
+          <div className='flex items-center justify-between px-3 py-1 border-b border-[#161616] text-[#555]'>
+            <span>console</span>
+            <button
+              onClick={() => setConsoleEntries([])}
+              className='hover:text-[#eaeaea]'
+            >
+              clear
+            </button>
+          </div>
           {consoleEntries.length === 0 ? (
             <p className='px-3 py-2 text-[#555]'>
               Console is empty — logs and errors from the preview appear here.
@@ -798,14 +940,27 @@ export default function CoderSpace() {
             }
             className='flex-1 rounded-xl bg-[#161616] border border-[#262626] focus:border-[#6c2fff] outline-none px-4 py-2.5 text-sm placeholder:text-[#555]'
           />
-          <Button
-            type='submit'
-            disabled={busy}
-            className='rounded-xl bg-[#6c2fff] hover:bg-[#5a1fe0]'
-            aria-label='Send prompt'
-          >
-            <Send className='w-4 h-4' />
-          </Button>
+          {busy ? (
+            <Button
+              type='button'
+              onClick={() => {
+                cancelRef.current = true;
+                setStatus('Stopping…');
+              }}
+              className='rounded-xl bg-[#ff3c75] hover:bg-[#e02a60]'
+              aria-label='Stop generating'
+            >
+              <Square className='w-4 h-4' />
+            </Button>
+          ) : (
+            <Button
+              type='submit'
+              className='rounded-xl bg-[#6c2fff] hover:bg-[#5a1fe0]'
+              aria-label='Send prompt'
+            >
+              <Send className='w-4 h-4' />
+            </Button>
+          )}
         </form>
         {(status || aiBackup) && (
           <div className='flex items-center gap-3 px-1'>

--- a/lib/space-engine.ts
+++ b/lib/space-engine.ts
@@ -125,6 +125,101 @@ export interface ConsoleEntry {
   text: string;
 }
 
+export interface SpaceProject {
+  id: string;
+  name: string;
+  updatedAt: number;
+  files: Array<Pick<FileContent, 'name' | 'content' | 'type'>>;
+}
+
+export const MAX_PROJECTS = 12;
+
+/** Insert or update a project, newest first, capped at MAX_PROJECTS. */
+export function upsertProject(
+  projects: SpaceProject[],
+  project: SpaceProject,
+  cap = MAX_PROJECTS
+): SpaceProject[] {
+  const rest = projects.filter(p => p.id !== project.id);
+  return [project, ...rest]
+    .sort((a, b) => b.updatedAt - a.updatedAt)
+    .slice(0, cap);
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function base64UrlToBytes(encoded: string): Uint8Array {
+  const b64 = encoded.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(b64);
+  return Uint8Array.from(binary, c => c.charCodeAt(0));
+}
+
+async function pipeThrough(
+  bytes: Uint8Array,
+  stream: CompressionStream | DecompressionStream
+): Promise<Uint8Array> {
+  const source = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(bytes);
+      controller.close();
+    },
+  });
+  // CompressionStream's lib typing (BufferSource) doesn't line up with
+  // pipeThrough's generics, but the shapes are compatible at runtime.
+  const readable = source.pipeThrough(
+    stream as unknown as ReadableWritablePair<Uint8Array, Uint8Array>
+  );
+  return new Uint8Array(await new Response(readable).arrayBuffer());
+}
+
+/**
+ * Encode a project into a URL-safe string (gzip + base64url when the
+ * browser supports CompressionStream, plain base64url otherwise). The
+ * `1.`/`0.` prefix records which so any encoding can be decoded anywhere.
+ */
+export async function encodeProjectToHash(
+  name: string,
+  files: Array<Pick<FileContent, 'name' | 'content' | 'type'>>
+): Promise<string> {
+  const json = new TextEncoder().encode(JSON.stringify({ name, files }));
+  if (typeof CompressionStream !== 'undefined') {
+    const compressed = await pipeThrough(json, new CompressionStream('gzip'));
+    return `1.${bytesToBase64Url(compressed)}`;
+  }
+  return `0.${bytesToBase64Url(json)}`;
+}
+
+/** Reverse of encodeProjectToHash. Returns null for anything malformed. */
+export async function decodeProjectFromHash(encoded: string): Promise<{
+  name: string;
+  files: Array<Pick<FileContent, 'name' | 'content' | 'type'>>;
+} | null> {
+  try {
+    const [version, payload] = encoded.split('.', 2);
+    if (!payload) return null;
+    let bytes = base64UrlToBytes(payload);
+    if (version === '1') {
+      bytes = await pipeThrough(bytes, new DecompressionStream('gzip'));
+    } else if (version !== '0') {
+      return null;
+    }
+    const parsed = JSON.parse(new TextDecoder().decode(bytes));
+    if (!parsed?.name || !Array.isArray(parsed.files) || !parsed.files.length) {
+      return null;
+    }
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * System prompt for the Coder Space AI. Overrides the chat-oriented default
  * prompt, which encourages step-by-step narration — here the model's entire
@@ -392,7 +487,7 @@ body { font-family: system-ui, sans-serif; color: #eaeaea; background: #0d0d0d; 
 <body>
   <main>
     <h1>Snake</h1>
-    <p>Arrow keys to move · <span id="score">0</span> points</p>
+    <p>Arrow keys or swipe · <span id="score">0</span> points</p>
     <canvas id="game" width="300" height="300"></canvas>
   </main>
   <script src="app.js"></script>
@@ -416,10 +511,29 @@ const ctx = canvas.getContext('2d');
 const CELL = 15, SIZE = 20;
 let snake = [{ x: 10, y: 10 }], dir = { x: 1, y: 0 }, food = { x: 5, y: 5 }, score = 0;
 
+function turn(t) {
+  if (t.x !== -dir.x || t.y !== -dir.y) dir = t;
+}
+
 document.addEventListener('keydown', e => {
   const turns = { ArrowUp: { x: 0, y: -1 }, ArrowDown: { x: 0, y: 1 }, ArrowLeft: { x: -1, y: 0 }, ArrowRight: { x: 1, y: 0 } };
-  const t = turns[e.key];
-  if (t && (t.x !== -dir.x || t.y !== -dir.y)) dir = t;
+  if (turns[e.key]) { e.preventDefault(); turn(turns[e.key]); }
+});
+
+// Swipe to steer on touch screens
+let touchStart = null;
+canvas.addEventListener('touchstart', e => {
+  touchStart = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+}, { passive: true });
+canvas.addEventListener('touchmove', e => e.preventDefault(), { passive: false });
+canvas.addEventListener('touchend', e => {
+  if (!touchStart) return;
+  const dx = e.changedTouches[0].clientX - touchStart.x;
+  const dy = e.changedTouches[0].clientY - touchStart.y;
+  touchStart = null;
+  if (Math.abs(dx) < 20 && Math.abs(dy) < 20) return;
+  if (Math.abs(dx) > Math.abs(dy)) turn({ x: dx > 0 ? 1 : -1, y: 0 });
+  else turn({ x: 0, y: dy > 0 ? 1 : -1 });
 });
 
 function tick() {


### PR DESCRIPTION
## Summary

A blunt audit of Coder Space's real weaknesses, then fixes for all of them:

- **Silent data loss (worst flaw) fixed**: instead of one autosave slot that a new template overwrote forever, projects now live in a capped list (`wr-space-projects`, newest-first, max 12) with the legacy single slot migrated once. The launch screen lists recent projects with time-ago labels, open-on-tap, and per-project delete.
- **Zero-backend share links**: the Share button compresses the project (gzip via `CompressionStream` → base64url, plain-base64 fallback) into a `/#p=…` URL and copies it; opening such a link loads the project straight into the workspace as a new local copy. Links over ~24 KB are refused with a pointer to ZIP export.
- **Preview no longer restarts on every keystroke**: rebuilds are debounced 500 ms (first build immediate), so a running game survives typing, and AI streaming reloads the preview only once the response settles.
- **In-flight AI generation can be stopped**: the send button becomes a stop button while busy; complete files already streamed still apply.
- **Snake is now playable on phones**: swipe steering with scroll suppression on the canvas, alongside arrow keys.
- **Console panel** gains a header with a clear action.

## Verification

- Engine logic unit-tested: `upsertProject` ordering/cap, share encode/decode with unicode round-trip and malformed-input rejection — 51 tests passing, typecheck clean
- Browser-driven at 390px: seeded projects render with time-ago labels, opening one loads its file tabs, the share link's gzip payload decodes (verified with Node `zlib.gunzipSync`) to the exact project name and files, and console clear empties the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DLB9LkuQiDdeG8phXB95q

---
_Generated by [Claude Code](https://claude.ai/code/session_014DLB9LkuQiDdeG8phXB95q)_