### PR TITLE
Pack Coder Space projects into an installable PWA on Deploy

### DIFF
--- a/__tests__/space-engine.test.ts
+++ b/__tests__/space-engine.test.ts
@@ -2,12 +2,13 @@
  * Coder Space engine tests
  */
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   MAX_PROJECTS,
   SPACE_SYSTEM_PROMPT,
   SPACE_TEMPLATES,
   SpaceProject,
+  buildDeployableFiles,
   buildPreviewHtml,
   decodeProjectFromHash,
   encodeProjectToHash,
@@ -246,5 +247,65 @@ describe('templates', () => {
     expect(fileTypeFromName('index.html')).toBe('html');
     expect(fileTypeFromName('style.css')).toBe('css');
     expect(fileTypeFromName('app.js')).toBe('js');
+  });
+});
+
+describe('buildDeployableFiles', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = vi.fn(async () => ({
+      arrayBuffer: async () => new Uint8Array([1, 2, 3]).buffer,
+    })) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('adds a manifest, service worker, and bundled icons, and wires them into index.html', async () => {
+    const files = [
+      {
+        name: 'index.html',
+        content:
+          '<html><head></head><body><script src="app.js"></script></body></html>',
+        type: 'html' as const,
+        lastModified: new Date(),
+      },
+      {
+        name: 'app.js',
+        content: 'console.log("hi");',
+        type: 'js' as const,
+        lastModified: new Date(),
+      },
+    ];
+
+    const out = await buildDeployableFiles(files, 'My Test App');
+    const names = out.map(f => f.name);
+
+    expect(names).toEqual(
+      expect.arrayContaining([
+        'index.html',
+        'app.js',
+        'manifest.json',
+        'sw.js',
+        'icon-192.png',
+        'icon-512.png',
+        'apple-touch-icon.png',
+      ])
+    );
+
+    const manifest = JSON.parse(
+      out.find(f => f.name === 'manifest.json')!.content
+    );
+    expect(manifest.name).toBe('My Test App');
+    expect(manifest.icons).toHaveLength(2);
+
+    const html = out.find(f => f.name === 'index.html')!.content;
+    expect(html).toContain('<link rel="manifest" href="manifest.json">');
+    expect(html).toContain("navigator.serviceWorker.register('sw.js')");
+
+    const icon = out.find(f => f.name === 'icon-192.png')!;
+    expect(icon.encoding).toBe('base64');
   });
 });

--- a/components/publish-modal.tsx
+++ b/components/publish-modal.tsx
@@ -14,6 +14,7 @@ import { ExternalLink, Globe2, LinkIcon } from 'lucide-react';
 import { FileContent } from '@/hooks/use-code-builder';
 import { VercelIntegration } from '@/lib/vercel-integration';
 import { NetlifyIntegration } from '@/lib/netlify-integration';
+import { buildDeployableFiles } from '@/lib/space-engine';
 
 type Platform = 'vercel' | 'netlify';
 
@@ -52,18 +53,23 @@ export default function PublishModal({
   const [error, setError] = useState<string | null>(null);
 
   const handleDeployVercel = async () => {
+    const deployableFiles = await buildDeployableFiles(files, projectName);
     const vercel = new VercelIntegration(apiToken);
     const deployment = await vercel.deployProject(
       projectName,
-      files,
+      deployableFiles,
       'production'
     );
     setDeployUrl(`https://${deployment.url}`);
   };
 
   const handleDeployNetlify = async () => {
+    const deployableFiles = await buildDeployableFiles(files, projectName);
     const netlify = new NetlifyIntegration(apiToken);
-    const deployment = await netlify.deployProject(projectName, files);
+    const deployment = await netlify.deployProject(
+      projectName,
+      deployableFiles
+    );
     setDeployUrl(`https://${NetlifyIntegration.getDeploymentUrl(deployment)}`);
   };
 
@@ -180,6 +186,12 @@ export default function PublishModal({
                 You can connect a custom domain later in{' '}
                 {PLATFORM_COPY[platform].label}. A shareable preview URL is
                 available immediately.
+              </div>
+              <div className='text-xs text-muted-foreground'>
+                Open this link on your phone and tap{' '}
+                <strong>Add to Home Screen</strong> (iPhone) or{' '}
+                <strong>Install app</strong> (Android) to add it like a real
+                app.
               </div>
             </div>
           )}

--- a/hooks/use-code-builder.ts
+++ b/hooks/use-code-builder.ts
@@ -9,6 +9,9 @@ export interface FileContent {
   content: string;
   type: 'html' | 'css' | 'js' | 'json' | 'md' | 'tsx' | 'ts' | 'py' | 'txt';
   lastModified: Date;
+  // How `content` is encoded. Defaults to 'utf8' when omitted — only set to
+  // 'base64' for binary assets (e.g. icons) bundled at deploy time.
+  encoding?: 'utf8' | 'base64';
 }
 
 export interface ProjectData {
@@ -22,21 +25,27 @@ export interface ProjectData {
 export function useCodeBuilder() {
   const [files, setFiles] = useState<FileContent[]>([]);
   const [selectedFile, setSelectedFile] = useState('index.html');
-  const [currentProject, setCurrentProject] = useState<ProjectData | null>(null);
+  const [currentProject, setCurrentProject] = useState<ProjectData | null>(
+    null
+  );
 
   // Save project to localStorage
   const saveProject = useCallback((project: ProjectData) => {
     localStorage.setItem(PROJECT_STORAGE_KEY, JSON.stringify(project));
-    
+
     // Update projects list
-    const projectsList = JSON.parse(localStorage.getItem(PROJECTS_LIST_KEY) || '[]');
-    const existingIndex = projectsList.findIndex((p: any) => p.id === project.id);
-    
+    const projectsList = JSON.parse(
+      localStorage.getItem(PROJECTS_LIST_KEY) || '[]'
+    );
+    const existingIndex = projectsList.findIndex(
+      (p: any) => p.id === project.id
+    );
+
     const projectSummary = {
       id: project.id,
       name: project.name,
       lastModified: project.lastModified,
-      fileCount: project.files.length
+      fileCount: project.files.length,
     };
 
     if (existingIndex >= 0) {
@@ -44,7 +53,7 @@ export function useCodeBuilder() {
     } else {
       projectsList.push(projectSummary);
     }
-    
+
     localStorage.setItem(PROJECTS_LIST_KEY, JSON.stringify(projectsList));
   }, []);
 
@@ -124,7 +133,7 @@ export function useCodeBuilder() {
 </body>
 </html>`,
         type: 'html',
-        lastModified: new Date()
+        lastModified: new Date(),
       },
       {
         name: 'style.css',
@@ -349,7 +358,7 @@ body {
   }
 }`,
         type: 'css',
-        lastModified: new Date()
+        lastModified: new Date(),
       },
       {
         name: 'app.js',
@@ -546,8 +555,8 @@ document.addEventListener('mousemove', function(e) {
   document.body.style.backgroundPosition = \`\${50 + x * 5}% \${50 + y * 5}%\`;
 });`,
         type: 'js',
-        lastModified: new Date()
-      }
+        lastModified: new Date(),
+      },
     ];
 
     const project: ProjectData = {
@@ -555,7 +564,7 @@ document.addEventListener('mousemove', function(e) {
       name: 'My Project',
       files: defaultFiles,
       lastModified: new Date(),
-      selectedFile: 'index.html'
+      selectedFile: 'index.html',
     };
 
     setFiles(defaultFiles);
@@ -572,10 +581,10 @@ document.addEventListener('mousemove', function(e) {
         // Convert date strings back to Date objects
         project.files = project.files.map(file => ({
           ...file,
-          lastModified: new Date(file.lastModified)
+          lastModified: new Date(file.lastModified),
         }));
         project.lastModified = new Date(project.lastModified);
-        
+
         setFiles(project.files);
         setSelectedFile(project.selectedFile);
         setCurrentProject(project);
@@ -596,9 +605,9 @@ document.addEventListener('mousemove', function(e) {
         ...currentProject,
         files,
         selectedFile,
-        lastModified: new Date()
+        lastModified: new Date(),
       };
-      
+
       // Debounce save to avoid too frequent saves
       const timeoutId = setTimeout(() => {
         setCurrentProject(updatedProject);
@@ -610,29 +619,34 @@ document.addEventListener('mousemove', function(e) {
   }, [files, selectedFile, saveProject]);
 
   const updateFileContent = useCallback((fileName: string, content: string) => {
-    setFiles(prev => prev.map(file => 
-      file.name === fileName ? { ...file, content, lastModified: new Date() } : file
-    ));
+    setFiles(prev =>
+      prev.map(file =>
+        file.name === fileName
+          ? { ...file, content, lastModified: new Date() }
+          : file
+      )
+    );
   }, []);
 
-  const addNewFile = useCallback((name: string, type: FileContent['type'] = 'html') => {
-    try {
-      // Validate inputs
-      if (!name || typeof name !== 'string') {
-        console.warn('addNewFile: Invalid filename provided:', name);
-        return;
-      }
+  const addNewFile = useCallback(
+    (name: string, type: FileContent['type'] = 'html') => {
+      try {
+        // Validate inputs
+        if (!name || typeof name !== 'string') {
+          console.warn('addNewFile: Invalid filename provided:', name);
+          return;
+        }
 
-      // Check if file already exists
-      const existingFile = files.find(f => f.name === name);
-      if (existingFile) {
-        // File already exists, just select it
-        setSelectedFile(name);
-        return;
-      }
+        // Check if file already exists
+        const existingFile = files.find(f => f.name === name);
+        if (existingFile) {
+          // File already exists, just select it
+          setSelectedFile(name);
+          return;
+        }
 
-    const defaultContent = {
-      html: `<!DOCTYPE html>
+        const defaultContent = {
+          html: `<!DOCTYPE html>
 <html>
 <head>
   <title>New File</title>
@@ -641,9 +655,9 @@ document.addEventListener('mousemove', function(e) {
 
 </body>
 </html>`,
-      css: '/* CSS styles */',
-      js: '// JavaScript code',
-      tsx: `import React from 'react';
+          css: '/* CSS styles */',
+          js: '// JavaScript code',
+          tsx: `import React from 'react';
 
 export default function Component() {
   return (
@@ -652,26 +666,28 @@ export default function Component() {
     </div>
   );
 }`,
-      ts: '// TypeScript code',
-      py: '# Python code',
-      json: '{}',
-      md: '# New File',
-      txt: 'New text file'
-    };
+          ts: '// TypeScript code',
+          py: '# Python code',
+          json: '{}',
+          md: '# New File',
+          txt: 'New text file',
+        };
 
-    const newFile: FileContent = {
-      name,
-      content: defaultContent[type] || '',
-      type,
-      lastModified: new Date()
-    };
+        const newFile: FileContent = {
+          name,
+          content: defaultContent[type] || '',
+          type,
+          lastModified: new Date(),
+        };
 
-    setFiles(prev => [...prev, newFile]);
-    setSelectedFile(name);
-    } catch (error) {
-      console.error('Error in addNewFile:', error);
-    }
-  }, [files]);
+        setFiles(prev => [...prev, newFile]);
+        setSelectedFile(name);
+      } catch (error) {
+        console.error('Error in addNewFile:', error);
+      }
+    },
+    [files]
+  );
 
   // Remove duplicate files
   const removeDuplicateFiles = useCallback(() => {
@@ -696,74 +712,113 @@ export default function Component() {
     }
   }, [files, removeDuplicateFiles]);
 
-  const deleteFile = useCallback((fileName: string) => {
-    setFiles(prev => prev.filter(file => file.name !== fileName));
-    if (selectedFile === fileName) {
-      setSelectedFile(files[0]?.name || 'index.html');
-    }
-  }, [selectedFile, files]);
+  const deleteFile = useCallback(
+    (fileName: string) => {
+      setFiles(prev => prev.filter(file => file.name !== fileName));
+      if (selectedFile === fileName) {
+        setSelectedFile(files[0]?.name || 'index.html');
+      }
+    },
+    [selectedFile, files]
+  );
 
   // AI Integration: Create or update file from AI response
-  const createOrUpdateFileFromAI = useCallback((fileName: string, content: string, type: FileContent['type']) => {
-    const existingFile = files.find(f => f.name === fileName);
-    
-    if (existingFile) {
-      // Update existing file
-      updateFileContent(fileName, content);
-    } else {
-      // Create new file
-      const newFile: FileContent = {
-        name: fileName,
-        content,
-        type,
-        lastModified: new Date()
-      };
-      setFiles(prev => [...prev, newFile]);
-    }
-    
-    // Switch to the updated/created file
-    setSelectedFile(fileName);
-  }, [files, updateFileContent]);
+  const createOrUpdateFileFromAI = useCallback(
+    (fileName: string, content: string, type: FileContent['type']) => {
+      const existingFile = files.find(f => f.name === fileName);
+
+      if (existingFile) {
+        // Update existing file
+        updateFileContent(fileName, content);
+      } else {
+        // Create new file
+        const newFile: FileContent = {
+          name: fileName,
+          content,
+          type,
+          lastModified: new Date(),
+        };
+        setFiles(prev => [...prev, newFile]);
+      }
+
+      // Switch to the updated/created file
+      setSelectedFile(fileName);
+    },
+    [files, updateFileContent]
+  );
 
   // AI Integration: Apply multiple file changes from AI response
-  const applyAIChanges = useCallback((changes: Array<{fileName: string, content: string, type: FileContent['type']}>) => {
-    changes.forEach(change => {
-      createOrUpdateFileFromAI(change.fileName, change.content, change.type);
-    });
-  }, [createOrUpdateFileFromAI]);
+  const applyAIChanges = useCallback(
+    (
+      changes: Array<{
+        fileName: string;
+        content: string;
+        type: FileContent['type'];
+      }>
+    ) => {
+      changes.forEach(change => {
+        createOrUpdateFileFromAI(change.fileName, change.content, change.type);
+      });
+    },
+    [createOrUpdateFileFromAI]
+  );
 
   // Parse AI response for code blocks and apply them
-  const parseAndApplyAIResponse = useCallback((aiResponse: string) => {
-    const codeBlockRegex = /```(\w+)?\s*(?:\/\/\s*(.+\.(?:html|css|js|json|md|tsx|ts|py|txt)))?\n([\s\S]*?)```/g;
-    const changes: Array<{fileName: string, content: string, type: FileContent['type']}> = [];
-    let match;
+  const parseAndApplyAIResponse = useCallback(
+    (aiResponse: string) => {
+      const codeBlockRegex =
+        /```(\w+)?\s*(?:\/\/\s*(.+\.(?:html|css|js|json|md|tsx|ts|py|txt)))?\n([\s\S]*?)```/g;
+      const changes: Array<{
+        fileName: string;
+        content: string;
+        type: FileContent['type'];
+      }> = [];
+      let match;
 
-    while ((match = codeBlockRegex.exec(aiResponse)) !== null) {
-      const language = match[1]?.toLowerCase() || '';
-      const fileName = match[2] || `generated.${language}`;
-      const content = match[3].trim();
-      
-      // Determine file type from language or extension
-      let type: FileContent['type'] = 'html';
-      if (language === 'css' || fileName.endsWith('.css')) type = 'css';
-      else if (language === 'javascript' || language === 'js' || fileName.endsWith('.js')) type = 'js';
-      else if (language === 'json' || fileName.endsWith('.json')) type = 'json';
-      else if (language === 'typescript' || language === 'ts' || fileName.endsWith('.ts')) type = 'ts';
-      else if (language === 'tsx' || fileName.endsWith('.tsx')) type = 'tsx';
-      else if (language === 'python' || language === 'py' || fileName.endsWith('.py')) type = 'py';
-      else if (fileName.endsWith('.md')) type = 'md';
-      else if (fileName.endsWith('.txt')) type = 'txt';
-      
-      changes.push({ fileName, content, type });
-    }
+      while ((match = codeBlockRegex.exec(aiResponse)) !== null) {
+        const language = match[1]?.toLowerCase() || '';
+        const fileName = match[2] || `generated.${language}`;
+        const content = match[3].trim();
 
-    if (changes.length > 0) {
-      applyAIChanges(changes);
-      return changes.length;
-    }
-    
-    return 0;
-  }, [applyAIChanges]);
+        // Determine file type from language or extension
+        let type: FileContent['type'] = 'html';
+        if (language === 'css' || fileName.endsWith('.css')) type = 'css';
+        else if (
+          language === 'javascript' ||
+          language === 'js' ||
+          fileName.endsWith('.js')
+        )
+          type = 'js';
+        else if (language === 'json' || fileName.endsWith('.json'))
+          type = 'json';
+        else if (
+          language === 'typescript' ||
+          language === 'ts' ||
+          fileName.endsWith('.ts')
+        )
+          type = 'ts';
+        else if (language === 'tsx' || fileName.endsWith('.tsx')) type = 'tsx';
+        else if (
+          language === 'python' ||
+          language === 'py' ||
+          fileName.endsWith('.py')
+        )
+          type = 'py';
+        else if (fileName.endsWith('.md')) type = 'md';
+        else if (fileName.endsWith('.txt')) type = 'txt';
+
+        changes.push({ fileName, content, type });
+      }
+
+      if (changes.length > 0) {
+        applyAIChanges(changes);
+        return changes.length;
+      }
+
+      return 0;
+    },
+    [applyAIChanges]
+  );
 
   const getSelectedFileContent = useCallback(() => {
     return files.find(file => file.name === selectedFile)?.content || '';
@@ -781,7 +836,7 @@ export default function Component() {
       fileNames: files.map(f => f.name),
       dependencies: [] as string[],
       frameworks: [] as string[],
-      patterns: [] as string[]
+      patterns: [] as string[],
     };
 
     // Analyze files for dependencies and frameworks
@@ -789,42 +844,63 @@ export default function Component() {
       const content = file.content.toLowerCase();
 
       // Detect frameworks
-      if (content.includes('react') || content.includes('jsx') || content.includes('usestate')) {
-        if (!context.frameworks.includes('React')) context.frameworks.push('React');
+      if (
+        content.includes('react') ||
+        content.includes('jsx') ||
+        content.includes('usestate')
+      ) {
+        if (!context.frameworks.includes('React'))
+          context.frameworks.push('React');
       }
       if (content.includes('vue') || content.includes('v-')) {
         if (!context.frameworks.includes('Vue')) context.frameworks.push('Vue');
       }
       if (content.includes('angular') || content.includes('@component')) {
-        if (!context.frameworks.includes('Angular')) context.frameworks.push('Angular');
+        if (!context.frameworks.includes('Angular'))
+          context.frameworks.push('Angular');
       }
       if (content.includes('tailwind') || content.includes('tw-')) {
-        if (!context.frameworks.includes('Tailwind')) context.frameworks.push('Tailwind');
+        if (!context.frameworks.includes('Tailwind'))
+          context.frameworks.push('Tailwind');
       }
       if (content.includes('bootstrap') || content.includes('btn-')) {
-        if (!context.frameworks.includes('Bootstrap')) context.frameworks.push('Bootstrap');
+        if (!context.frameworks.includes('Bootstrap'))
+          context.frameworks.push('Bootstrap');
       }
 
       // Detect common patterns
       if (content.includes('async') && content.includes('await')) {
-        if (!context.patterns.includes('async/await')) context.patterns.push('async/await');
+        if (!context.patterns.includes('async/await'))
+          context.patterns.push('async/await');
       }
       if (content.includes('fetch(') || content.includes('axios')) {
-        if (!context.patterns.includes('API calls')) context.patterns.push('API calls');
+        if (!context.patterns.includes('API calls'))
+          context.patterns.push('API calls');
       }
-      if (content.includes('localstorage') || content.includes('sessionstorage')) {
-        if (!context.patterns.includes('Local storage')) context.patterns.push('Local storage');
+      if (
+        content.includes('localstorage') ||
+        content.includes('sessionstorage')
+      ) {
+        if (!context.patterns.includes('Local storage'))
+          context.patterns.push('Local storage');
       }
       if (content.includes('eventlistener') || content.includes('onclick')) {
-        if (!context.patterns.includes('Event handling')) context.patterns.push('Event handling');
+        if (!context.patterns.includes('Event handling'))
+          context.patterns.push('Event handling');
       }
 
       // Extract import statements for dependencies
-      const importMatches = file.content.match(/import.*from\s+['"]([^'"]+)['"]/g);
+      const importMatches = file.content.match(
+        /import.*from\s+['"]([^'"]+)['"]/g
+      );
       if (importMatches) {
         importMatches.forEach(match => {
           const dep = match.match(/from\s+['"]([^'"]+)['"]/)?.[1];
-          if (dep && !dep.startsWith('.') && !context.dependencies.includes(dep)) {
+          if (
+            dep &&
+            !dep.startsWith('.') &&
+            !context.dependencies.includes(dep)
+          ) {
             context.dependencies.push(dep);
           }
         });
@@ -835,92 +911,116 @@ export default function Component() {
   }, [files]);
 
   // Get related files for context
-  const getRelatedFiles = useCallback((currentFile: string, maxFiles: number = 5) => {
-    if (!currentFile) return [];
+  const getRelatedFiles = useCallback(
+    (currentFile: string, maxFiles: number = 5) => {
+      if (!currentFile) return [];
 
-    const currentFileExt = currentFile.split('.').pop()?.toLowerCase();
-    const currentFileBase = currentFile.replace(/\.[^/.]+$/, '');
+      const currentFileExt = currentFile.split('.').pop()?.toLowerCase();
+      const currentFileBase = currentFile.replace(/\.[^/.]+$/, '');
 
-    return files
-      .filter(file => file.name !== currentFile)
-      .sort((a, b) => {
-        let scoreA = 0;
-        let scoreB = 0;
+      return files
+        .filter(file => file.name !== currentFile)
+        .sort((a, b) => {
+          let scoreA = 0;
+          let scoreB = 0;
 
-        // Same extension gets higher score
-        if (a.name.endsWith(`.${currentFileExt}`)) scoreA += 3;
-        if (b.name.endsWith(`.${currentFileExt}`)) scoreB += 3;
+          // Same extension gets higher score
+          if (a.name.endsWith(`.${currentFileExt}`)) scoreA += 3;
+          if (b.name.endsWith(`.${currentFileExt}`)) scoreB += 3;
 
-        // Similar base name gets higher score
-        if (a.name.includes(currentFileBase) || currentFileBase.includes(a.name.replace(/\.[^/.]+$/, ''))) {
-          scoreA += 5;
-        }
-        if (b.name.includes(currentFileBase) || currentFileBase.includes(b.name.replace(/\.[^/.]+$/, ''))) {
-          scoreB += 5;
-        }
+          // Similar base name gets higher score
+          if (
+            a.name.includes(currentFileBase) ||
+            currentFileBase.includes(a.name.replace(/\.[^/.]+$/, ''))
+          ) {
+            scoreA += 5;
+          }
+          if (
+            b.name.includes(currentFileBase) ||
+            currentFileBase.includes(b.name.replace(/\.[^/.]+$/, ''))
+          ) {
+            scoreB += 5;
+          }
 
-        // Files with imports/references get higher score
-        const currentContent = files.find(f => f.name === currentFile)?.content || '';
-        if (currentContent.includes(a.name) || a.content.includes(currentFile)) scoreA += 2;
-        if (currentContent.includes(b.name) || b.content.includes(currentFile)) scoreB += 2;
+          // Files with imports/references get higher score
+          const currentContent =
+            files.find(f => f.name === currentFile)?.content || '';
+          if (
+            currentContent.includes(a.name) ||
+            a.content.includes(currentFile)
+          )
+            scoreA += 2;
+          if (
+            currentContent.includes(b.name) ||
+            b.content.includes(currentFile)
+          )
+            scoreB += 2;
 
-        return scoreB - scoreA;
-      })
-      .slice(0, maxFiles);
-  }, [files]);
+          return scoreB - scoreA;
+        })
+        .slice(0, maxFiles);
+    },
+    [files]
+  );
 
   // Extract symbols from file for completion context
-  const extractFileSymbols = useCallback((fileName: string) => {
-    const file = files.find(f => f.name === fileName);
-    if (!file) return { functions: [], variables: [], classes: [], exports: [] };
+  const extractFileSymbols = useCallback(
+    (fileName: string) => {
+      const file = files.find(f => f.name === fileName);
+      if (!file)
+        return { functions: [], variables: [], classes: [], exports: [] };
 
-    const content = file.content;
-    const symbols = {
-      functions: [] as string[],
-      variables: [] as string[],
-      classes: [] as string[],
-      exports: [] as string[]
-    };
+      const content = file.content;
+      const symbols = {
+        functions: [] as string[],
+        variables: [] as string[],
+        classes: [] as string[],
+        exports: [] as string[],
+      };
 
-    // Extract functions
-    const functionRegex = /(?:function\s+([a-zA-Z_$][a-zA-Z0-9_$]*)|const\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=\s*(?:async\s+)?\([^)]*\)\s*=>|([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:\s*(?:async\s+)?\([^)]*\)\s*=>)/g;
-    let match;
-    while ((match = functionRegex.exec(content)) !== null) {
-      const funcName = match[1] || match[2] || match[3];
-      if (funcName && !symbols.functions.includes(funcName)) {
-        symbols.functions.push(funcName);
+      // Extract functions
+      const functionRegex =
+        /(?:function\s+([a-zA-Z_$][a-zA-Z0-9_$]*)|const\s+([a-zA-Z_$][a-zA-Z0-9_$]*)\s*=\s*(?:async\s+)?\([^)]*\)\s*=>|([a-zA-Z_$][a-zA-Z0-9_$]*)\s*:\s*(?:async\s+)?\([^)]*\)\s*=>)/g;
+      let match;
+      while ((match = functionRegex.exec(content)) !== null) {
+        const funcName = match[1] || match[2] || match[3];
+        if (funcName && !symbols.functions.includes(funcName)) {
+          symbols.functions.push(funcName);
+        }
       }
-    }
 
-    // Extract variables
-    const variableRegex = /(?:const|let|var)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/g;
-    while ((match = variableRegex.exec(content)) !== null) {
-      const varName = match[1];
-      if (varName && !symbols.variables.includes(varName)) {
-        symbols.variables.push(varName);
+      // Extract variables
+      const variableRegex = /(?:const|let|var)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/g;
+      while ((match = variableRegex.exec(content)) !== null) {
+        const varName = match[1];
+        if (varName && !symbols.variables.includes(varName)) {
+          symbols.variables.push(varName);
+        }
       }
-    }
 
-    // Extract classes
-    const classRegex = /class\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/g;
-    while ((match = classRegex.exec(content)) !== null) {
-      const className = match[1];
-      if (className && !symbols.classes.includes(className)) {
-        symbols.classes.push(className);
+      // Extract classes
+      const classRegex = /class\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/g;
+      while ((match = classRegex.exec(content)) !== null) {
+        const className = match[1];
+        if (className && !symbols.classes.includes(className)) {
+          symbols.classes.push(className);
+        }
       }
-    }
 
-    // Extract exports
-    const exportRegex = /export\s+(?:default\s+)?(?:const|let|var|function|class)?\s*([a-zA-Z_$][a-zA-Z0-9_$]*)/g;
-    while ((match = exportRegex.exec(content)) !== null) {
-      const exportName = match[1];
-      if (exportName && !symbols.exports.includes(exportName)) {
-        symbols.exports.push(exportName);
+      // Extract exports
+      const exportRegex =
+        /export\s+(?:default\s+)?(?:const|let|var|function|class)?\s*([a-zA-Z_$][a-zA-Z0-9_$]*)/g;
+      while ((match = exportRegex.exec(content)) !== null) {
+        const exportName = match[1];
+        if (exportName && !symbols.exports.includes(exportName)) {
+          symbols.exports.push(exportName);
+        }
       }
-    }
 
-    return symbols;
-  }, [files]);
+      return symbols;
+    },
+    [files]
+  );
 
   return {
     files,
@@ -943,39 +1043,49 @@ export default function Component() {
     // Context analysis methods
     getProjectContext,
     getRelatedFiles,
-    extractFileSymbols
+    extractFileSymbols,
   };
 }
 
 export function useCodeExport() {
-  const exportAsZip = useCallback(async (files: FileContent[], appName: string) => {
-    try {
-      const zip = new JSZip();
-      
-      // Add all files to the zip
-      files.forEach(file => {
-        zip.file(file.name, file.content);
-      });
-      
-      // Generate the zip file
-      const content = await zip.generateAsync({ type: 'blob' });
-      
-      // Download the zip
-      const url = URL.createObjectURL(content);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${appName.toLowerCase().replace(/\s+/g, '-')}-project.zip`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-    } catch (error) {
-      console.error('Error creating zip file:', error);
-    }
-  }, []);
+  const exportAsZip = useCallback(
+    async (files: FileContent[], appName: string) => {
+      try {
+        const zip = new JSZip();
+
+        // Add all files to the zip
+        files.forEach(file => {
+          zip.file(file.name, file.content);
+        });
+
+        // Generate the zip file
+        const content = await zip.generateAsync({ type: 'blob' });
+
+        // Download the zip
+        const url = URL.createObjectURL(content);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${appName.toLowerCase().replace(/\s+/g, '-')}-project.zip`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      } catch (error) {
+        console.error('Error creating zip file:', error);
+      }
+    },
+    []
+  );
 
   const previewInNewTab = useCallback((files: FileContent[]) => {
-    console.log('Preview called with files:', files.map(f => ({ name: f.name, type: f.type, contentLength: f.content.length })));
+    console.log(
+      'Preview called with files:',
+      files.map(f => ({
+        name: f.name,
+        type: f.type,
+        contentLength: f.content.length,
+      }))
+    );
 
     // Try to find an HTML file to preview
     let htmlFile = files.find(f => f.name === 'index.html');
@@ -983,7 +1093,16 @@ export function useCodeExport() {
       htmlFile = files.find(f => f.type === 'html');
     }
 
-    console.log('Found HTML file:', htmlFile ? { name: htmlFile.name, type: htmlFile.type, contentPreview: htmlFile.content.substring(0, 200) + '...' } : null);
+    console.log(
+      'Found HTML file:',
+      htmlFile
+        ? {
+            name: htmlFile.name,
+            type: htmlFile.type,
+            contentPreview: htmlFile.content.substring(0, 200) + '...',
+          }
+        : null
+    );
 
     if (!htmlFile) {
       // If no HTML file, create a simple preview with the first file
@@ -1045,15 +1164,23 @@ export function useCodeExport() {
     // Find and embed CSS files
     const cssFiles = files.filter(f => f.type === 'css');
     cssFiles.forEach(cssFile => {
-      const linkRegex = new RegExp(`<link[^>]*href=["']${cssFile.name}["'][^>]*>`, 'gi');
+      const linkRegex = new RegExp(
+        `<link[^>]*href=["']${cssFile.name}["'][^>]*>`,
+        'gi'
+      );
       const styleTag = `<style>\n${cssFile.content}\n</style>`;
       completeHtml = completeHtml.replace(linkRegex, styleTag);
     });
 
     // Find and embed JavaScript files
-    const jsFiles = files.filter(f => f.type === 'js' || f.type === 'tsx' || f.type === 'ts');
+    const jsFiles = files.filter(
+      f => f.type === 'js' || f.type === 'tsx' || f.type === 'ts'
+    );
     jsFiles.forEach(jsFile => {
-      const scriptRegex = new RegExp(`<script[^>]*src=["']${jsFile.name}["'][^>]*></script>`, 'gi');
+      const scriptRegex = new RegExp(
+        `<script[^>]*src=["']${jsFile.name}["'][^>]*></script>`,
+        'gi'
+      );
       let jsContent = jsFile.content;
 
       // Handle TypeScript/JSX files - convert to plain JavaScript for preview
@@ -1092,7 +1219,10 @@ export function useCodeExport() {
       });
     </script>`;
 
-    completeHtml = completeHtml.replace('</head>', errorHandlingScript + '</head>');
+    completeHtml = completeHtml.replace(
+      '</head>',
+      errorHandlingScript + '</head>'
+    );
 
     const blob = new Blob([completeHtml], { type: 'text/html' });
     const url = URL.createObjectURL(blob);
@@ -1102,6 +1232,6 @@ export function useCodeExport() {
 
   return {
     exportAsZip,
-    previewInNewTab
+    previewInNewTab,
   };
 }

--- a/lib/netlify-integration.ts
+++ b/lib/netlify-integration.ts
@@ -63,7 +63,11 @@ export class NetlifyIntegration {
   private async buildZip(files: FileContent[]): Promise<Blob> {
     const zip = new JSZip();
     for (const file of files) {
-      zip.file(file.name, file.content);
+      zip.file(
+        file.name,
+        file.content,
+        file.encoding === 'base64' ? { base64: true } : undefined
+      );
     }
     return zip.generateAsync({ type: 'blob' });
   }

--- a/lib/space-engine.ts
+++ b/lib/space-engine.ts
@@ -377,6 +377,135 @@ export function buildPreviewHtml(
   return doc;
 }
 
+const PWA_ICONS = [
+  { src: '/icon-192.png', name: 'icon-192.png', sizes: '192x192' },
+  { src: '/icon-512.png', name: 'icon-512.png', sizes: '512x512' },
+] as const;
+const APPLE_ICON = {
+  src: '/apple-touch-icon.png',
+  name: 'apple-touch-icon.png',
+};
+
+async function fetchAsBase64(url: string): Promise<string> {
+  const res = await fetch(url);
+  const buffer = await res.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Turns a project's raw files into a deployable, installable PWA bundle:
+ * fetches the app's own generic icons, adds a manifest + minimal service
+ * worker, and wires both into index.html. Only used on the Deploy path —
+ * the sandboxed srcdoc preview iframe (buildPreviewHtml) can never register
+ * a real service worker or trigger an install prompt, so there's no point
+ * PWA-ifying it.
+ */
+export async function buildDeployableFiles(
+  files: FileContent[],
+  projectName: string
+): Promise<FileContent[]> {
+  const now = new Date();
+  const shortName = projectName.slice(0, 20) || 'My App';
+
+  const manifest = {
+    name: projectName || 'My App',
+    short_name: shortName,
+    start_url: '.',
+    display: 'standalone',
+    background_color: '#0d0d0d',
+    theme_color: '#6c2fff',
+    icons: PWA_ICONS.map(icon => ({
+      src: icon.name,
+      sizes: icon.sizes,
+      type: 'image/png',
+      purpose: 'any maskable',
+    })),
+  };
+
+  const cacheList = [
+    '.',
+    ...files.map(f => f.name),
+    'manifest.json',
+    ...PWA_ICONS.map(i => i.name),
+    APPLE_ICON.name,
+  ];
+  const swContent = `const CACHE_NAME = 'wr-app-${Date.now()}';
+const urlsToCache = ${JSON.stringify(cacheList)};
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(urlsToCache))
+  );
+});
+
+self.addEventListener('fetch', event => {
+  event.respondWith(
+    caches.match(event.request).then(response => response || fetch(event.request))
+  );
+});
+`;
+
+  const iconFiles: FileContent[] = await Promise.all(
+    [...PWA_ICONS, APPLE_ICON].map(async icon => ({
+      name: icon.name,
+      content: await fetchAsBase64(icon.src),
+      type: 'txt' as const,
+      lastModified: now,
+      encoding: 'base64' as const,
+    }))
+  );
+
+  const pwaTags = [
+    '<link rel="manifest" href="manifest.json">',
+    '<meta name="theme-color" content="#6c2fff">',
+    `<link rel="apple-touch-icon" href="${APPLE_ICON.name}">`,
+    '<meta name="apple-mobile-web-app-capable" content="yes">',
+    `<meta name="apple-mobile-web-app-title" content="${shortName}">`,
+  ].join('\n');
+  const swRegisterScript = `<script>
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('sw.js');
+}
+</script>`;
+
+  const outFiles = files.map(f => ({ ...f }));
+  const htmlIndex = outFiles.findIndex(
+    f => f.name.toLowerCase() === 'index.html'
+  );
+  if (htmlIndex !== -1) {
+    let doc = outFiles[htmlIndex].content;
+    doc = doc.includes('<head>')
+      ? doc.replace('<head>', `<head>\n${pwaTags}`)
+      : pwaTags + doc;
+    doc = doc.includes('</body>')
+      ? doc.replace('</body>', `${swRegisterScript}\n</body>`)
+      : doc + swRegisterScript;
+    outFiles[htmlIndex] = { ...outFiles[htmlIndex], content: doc };
+  }
+
+  return [
+    ...outFiles,
+    {
+      name: 'manifest.json',
+      content: JSON.stringify(manifest, null, 2),
+      type: 'json',
+      lastModified: now,
+    },
+    {
+      name: 'sw.js',
+      content: swContent,
+      type: 'js',
+      lastModified: now,
+    },
+    ...iconFiles,
+  ];
+}
+
 export const SPACE_TEMPLATES: SpaceTemplate[] = [
   {
     id: 'blank',

--- a/lib/vercel-integration.ts
+++ b/lib/vercel-integration.ts
@@ -40,7 +40,7 @@ export class VercelIntegration {
     const response = await fetch(`${this.baseUrl}${endpoint}`, {
       ...options,
       headers: {
-        'Authorization': `Bearer ${this.apiToken}`,
+        Authorization: `Bearer ${this.apiToken}`,
         'Content-Type': 'application/json',
         ...options.headers,
       },
@@ -62,9 +62,12 @@ export class VercelIntegration {
     return this.makeRequest('/v9/projects');
   }
 
-  async createProject(name: string, gitRepository?: { type: 'github'; repo: string }) {
+  async createProject(
+    name: string,
+    gitRepository?: { type: 'github'; repo: string }
+  ) {
     const body: any = { name };
-    
+
     if (gitRepository) {
       body.gitRepository = gitRepository;
     }
@@ -76,15 +79,15 @@ export class VercelIntegration {
   }
 
   async deployProject(
-    projectName: string, 
-    files: FileContent[], 
+    projectName: string,
+    files: FileContent[],
     target: 'production' | 'preview' = 'production'
   ): Promise<VercelDeployment> {
     // Convert files to Vercel format
     const vercelFiles: VercelDeploymentFile[] = files.map(file => ({
       file: file.name,
       data: file.content,
-      encoding: 'utf8'
+      encoding: file.encoding ?? 'utf8',
     }));
 
     // Add package.json if not present
@@ -92,20 +95,24 @@ export class VercelIntegration {
     if (!hasPackageJson) {
       vercelFiles.push({
         file: 'package.json',
-        data: JSON.stringify({
-          name: projectName.toLowerCase().replace(/\s+/g, '-'),
-          version: '1.0.0',
-          description: 'PWA created with Hex & Kex',
-          main: 'index.html',
-          scripts: {
-            start: 'serve -s .',
-            build: 'echo "No build step required"'
+        data: JSON.stringify(
+          {
+            name: projectName.toLowerCase().replace(/\s+/g, '-'),
+            version: '1.0.0',
+            description: 'PWA created with Hex & Kex',
+            main: 'index.html',
+            scripts: {
+              start: 'serve -s .',
+              build: 'echo "No build step required"',
+            },
+            devDependencies: {
+              serve: '^14.0.0',
+            },
           },
-          devDependencies: {
-            serve: '^14.0.0'
-          }
-        }, null, 2),
-        encoding: 'utf8'
+          null,
+          2
+        ),
+        encoding: 'utf8',
       });
     }
 
@@ -114,37 +121,41 @@ export class VercelIntegration {
     if (!hasVercelJson) {
       vercelFiles.push({
         file: 'vercel.json',
-        data: JSON.stringify({
-          version: 2,
-          public: true,
-          headers: [
-            {
-              source: '/service-worker.js',
-              headers: [
-                {
-                  key: 'Cache-Control',
-                  value: 'public, max-age=0, must-revalidate'
-                }
-              ]
-            },
-            {
-              source: '/manifest.json',
-              headers: [
-                {
-                  key: 'Content-Type',
-                  value: 'application/manifest+json'
-                }
-              ]
-            }
-          ],
-          rewrites: [
-            {
-              source: '/(.*)',
-              destination: '/index.html'
-            }
-          ]
-        }, null, 2),
-        encoding: 'utf8'
+        data: JSON.stringify(
+          {
+            version: 2,
+            public: true,
+            headers: [
+              {
+                source: '/service-worker.js',
+                headers: [
+                  {
+                    key: 'Cache-Control',
+                    value: 'public, max-age=0, must-revalidate',
+                  },
+                ],
+              },
+              {
+                source: '/manifest.json',
+                headers: [
+                  {
+                    key: 'Content-Type',
+                    value: 'application/manifest+json',
+                  },
+                ],
+              },
+            ],
+            rewrites: [
+              {
+                source: '/(.*)',
+                destination: '/index.html',
+              },
+            ],
+          },
+          null,
+          2
+        ),
+        encoding: 'utf8',
       });
     }
 
@@ -156,13 +167,13 @@ export class VercelIntegration {
         buildCommand: null,
         outputDirectory: null,
         installCommand: null,
-        devCommand: null
+        devCommand: null,
       },
       target,
       meta: {
         'hex-kex-deployment': 'true',
-        'created-with': 'Hex & Kex PWA Builder'
-      }
+        'created-with': 'Hex & Kex PWA Builder',
+      },
     };
 
     return this.makeRequest('/v13/deployments', {
@@ -176,8 +187,8 @@ export class VercelIntegration {
   }
 
   async getDeployments(projectId?: string) {
-    const endpoint = projectId 
-      ? `/v6/deployments?projectId=${projectId}` 
+    const endpoint = projectId
+      ? `/v6/deployments?projectId=${projectId}`
       : '/v6/deployments';
     return this.makeRequest(endpoint);
   }
@@ -238,7 +249,7 @@ export const DEFAULT_PWA_CONFIG = {
   buildCommand: null,
   outputDirectory: null,
   installCommand: 'npm install',
-  devCommand: 'npm start'
+  devCommand: 'npm start',
 };
 
 // Common Vercel regions
@@ -250,5 +261,5 @@ export const VERCEL_REGIONS = [
   { id: 'sin1', name: 'Singapore' },
   { id: 'syd1', name: 'Sydney, Australia' },
   { id: 'hnd1', name: 'Tokyo, Japan' },
-  { id: 'gru1', name: 'São Paulo, Brazil' }
+  { id: 'gru1', name: 'São Paulo, Brazil' },
 ];


### PR DESCRIPTION
## Summary
- Add `buildDeployableFiles()` to `lib/space-engine.ts`: bundles the app's generic icons (`icon-192.png`, `icon-512.png`, `apple-touch-icon.png`), builds a `manifest.json` and a minimal offline-caching `sw.js`, and wires both into `index.html` (manifest link, theme-color, apple touch icon meta, service worker registration script). This only runs on the deploy path — the sandboxed `srcdoc` preview iframe can never register a service worker or trigger an install prompt, so `buildPreviewHtml` is untouched.
- Wire it into `PublishModal`'s Vercel/Netlify deploy handlers so every "Deploy" always ships an installable PWA — no new UI control needed, this is the natural conclusion of "ask the AI to build something, then install it on your phone."
- Add an `encoding?: 'utf8' | 'base64'` field to `FileContent` so binary icon bytes survive the deploy pipeline; thread it through `NetlifyIntegration.buildZip` (JSZip's base64 option) and `VercelIntegration.deployProject` (which already had per-file encoding support).
- Tell users how to install: the deploy success panel now points out "Add to Home Screen" (iPhone) / "Install app" (Android).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 52/52 passing, including a new `buildDeployableFiles` test asserting the manifest, service worker, and icon files are generated and correctly injected into `index.html`
- [x] Verified in a real browser: opening Coder Space's Deploy modal and clicking Deploy fetches all three icon assets and posts the resulting bundle to the Netlify API; the (network-blocked in this sandbox) failure is handled gracefully with a clean error message, no crash


---
_Generated by [Claude Code](https://claude.ai/code/session_014DLB9LkuQiDdeG8phXB95q)_