### PR TITLE
Fix Save/Test Connection staying disabled after entering an API key

### DIFF
--- a/components/ai-settings-panel.tsx
+++ b/components/ai-settings-panel.tsx
@@ -2,13 +2,28 @@ import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
 import { Slider } from '@/components/ui/slider';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { AISettings, AI_PROVIDERS, DEFAULT_SYSTEM_PROMPT } from '@/lib/ai-config';
-import { validateApiKey } from '@/lib/ai-service';
+import {
+  AISettings,
+  AI_PROVIDERS,
+  DEFAULT_SYSTEM_PROMPT,
+} from '@/lib/ai-config';
 import { Eye, EyeOff, TestTube, CheckCircle, XCircle } from 'lucide-react';
 
 interface AISettingsProps {
@@ -18,12 +33,21 @@ interface AISettingsProps {
   isConfigured: boolean;
 }
 
-export function AISettingsPanel({ settings, onSettingsChange, onTestConnection, isConfigured }: AISettingsProps) {
+export function AISettingsPanel({
+  settings,
+  onSettingsChange,
+  onTestConnection,
+  isConfigured,
+}: AISettingsProps) {
   const [showApiKey, setShowApiKey] = useState(false);
-  const [testStatus, setTestStatus] = useState<'idle' | 'testing' | 'success' | 'error'>('idle');
+  const [testStatus, setTestStatus] = useState<
+    'idle' | 'testing' | 'success' | 'error'
+  >('idle');
   const [localSettings, setLocalSettings] = useState(settings);
 
-  const currentProvider = AI_PROVIDERS.find(p => p.id === localSettings.provider);
+  const currentProvider = AI_PROVIDERS.find(
+    p => p.id === localSettings.provider
+  );
 
   const handleProviderChange = (providerId: string) => {
     const provider = AI_PROVIDERS.find(p => p.id === providerId);
@@ -32,7 +56,7 @@ export function AISettingsPanel({ settings, onSettingsChange, onTestConnection, 
         ...localSettings,
         provider: providerId,
         model: provider.models[0], // Set first model as default
-        apiKey: providerId === 'ollama' ? '' : localSettings.apiKey // Clear API key for Ollama
+        apiKey: providerId === 'ollama' ? '' : localSettings.apiKey, // Clear API key for Ollama
       });
     }
   };
@@ -53,40 +77,57 @@ export function AISettingsPanel({ settings, onSettingsChange, onTestConnection, 
     }
   };
 
-  const isValidConfig = currentProvider ? 
-    (!currentProvider.requiresApiKey || validateApiKey(localSettings.provider, localSettings.apiKey || '')) : 
-    false;
+  // Only require that a key was typed, not that it matches a guessed format —
+  // real key formats change over time and vary by provider (e.g. Mistral
+  // keys have no fixed prefix), so format-guessing here just blocks valid
+  // keys. Test Connection is the real validator: it calls the actual API.
+  const isValidConfig = currentProvider
+    ? !currentProvider.requiresApiKey || Boolean(localSettings.apiKey?.trim())
+    : false;
 
   return (
-    <Card className="w-full max-w-2xl">
+    <Card className='w-full max-w-2xl'>
       <CardHeader>
-        <div className="flex items-center justify-between">
+        <div className='flex items-center justify-between'>
           <div>
-            <CardTitle className="flex items-center gap-2">
+            <CardTitle className='flex items-center gap-2'>
               🤖 AI Assistant Setup
-              {isConfigured && <Badge variant="secondary" className="bg-green-100 text-green-800">Configured</Badge>}
+              {isConfigured && (
+                <Badge
+                  variant='secondary'
+                  className='bg-green-100 text-green-800'
+                >
+                  Configured
+                </Badge>
+              )}
             </CardTitle>
             <CardDescription>
-              Configure your AI provider to enable the coding assistant in White Rabbit
+              Configure your AI provider to enable the coding assistant in White
+              Rabbit
             </CardDescription>
           </div>
         </div>
       </CardHeader>
-      <CardContent className="space-y-6">
+      <CardContent className='space-y-6'>
         {/* Provider Selection */}
-        <div className="space-y-2">
-          <Label htmlFor="provider-select">AI Provider</Label>
-          <Select value={localSettings.provider} onValueChange={handleProviderChange}>
-            <SelectTrigger id="provider-select">
-              <SelectValue placeholder="Select AI provider" />
+        <div className='space-y-2'>
+          <Label htmlFor='provider-select'>AI Provider</Label>
+          <Select
+            value={localSettings.provider}
+            onValueChange={handleProviderChange}
+          >
+            <SelectTrigger id='provider-select'>
+              <SelectValue placeholder='Select AI provider' />
             </SelectTrigger>
             <SelectContent>
               {AI_PROVIDERS.map(provider => (
                 <SelectItem key={provider.id} value={provider.id}>
-                  <div className="flex items-center justify-between w-full">
+                  <div className='flex items-center justify-between w-full'>
                     <span>{provider.name}</span>
                     {!provider.requiresApiKey && (
-                      <Badge variant="outline" className="ml-2">Free</Badge>
+                      <Badge variant='outline' className='ml-2'>
+                        Free
+                      </Badge>
                     )}
                   </div>
                 </SelectItem>
@@ -97,39 +138,50 @@ export function AISettingsPanel({ settings, onSettingsChange, onTestConnection, 
 
         {/* API Key Input */}
         {currentProvider?.requiresApiKey && (
-          <div className="space-y-2">
-            <Label htmlFor="apiKey">API Key</Label>
-            <div className="relative">
+          <div className='space-y-2'>
+            <Label htmlFor='apiKey'>API Key</Label>
+            <div className='relative'>
               <Input
-                id="apiKey"
+                id='apiKey'
                 type={showApiKey ? 'text' : 'password'}
                 value={localSettings.apiKey || ''}
-                onChange={(e) => setLocalSettings({ ...localSettings, apiKey: e.target.value })}
+                onChange={e =>
+                  setLocalSettings({ ...localSettings, apiKey: e.target.value })
+                }
                 placeholder={`Enter your ${currentProvider.name} API key`}
-                className="pr-10"
+                className='pr-10'
               />
               <Button
-                type="button"
-                variant="ghost"
-                size="sm"
-                className="absolute right-0 top-0 h-full px-3"
+                type='button'
+                variant='ghost'
+                size='sm'
+                className='absolute right-0 top-0 h-full px-3'
                 onClick={() => setShowApiKey(!showApiKey)}
               >
-                {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                {showApiKey ? (
+                  <EyeOff className='h-4 w-4' />
+                ) : (
+                  <Eye className='h-4 w-4' />
+                )}
               </Button>
             </div>
-            <p className="text-sm text-gray-500">
+            <p className='text-sm text-gray-500'>
               Your API key is stored locally and never sent to our servers.
             </p>
           </div>
         )}
 
         {/* Model Selection */}
-        <div className="space-y-2">
-          <Label htmlFor="model-select">Model</Label>
-          <Select value={localSettings.model} onValueChange={(model) => setLocalSettings({ ...localSettings, model })}>
-            <SelectTrigger id="model-select">
-              <SelectValue placeholder="Select model" />
+        <div className='space-y-2'>
+          <Label htmlFor='model-select'>Model</Label>
+          <Select
+            value={localSettings.model}
+            onValueChange={model =>
+              setLocalSettings({ ...localSettings, model })
+            }
+          >
+            <SelectTrigger id='model-select'>
+              <SelectValue placeholder='Select model' />
             </SelectTrigger>
             <SelectContent>
               {currentProvider?.models.map(model => (
@@ -142,76 +194,99 @@ export function AISettingsPanel({ settings, onSettingsChange, onTestConnection, 
         </div>
 
         {/* Temperature Setting */}
-        <div className="space-y-2">
-          <Label htmlFor="temperature">
+        <div className='space-y-2'>
+          <Label htmlFor='temperature'>
             Temperature: {localSettings.temperature}
           </Label>
           <Slider
-            id="temperature"
+            id='temperature'
             min={0}
             max={2}
             step={0.1}
             value={[localSettings.temperature]}
-            onValueChange={([value]) => setLocalSettings({ ...localSettings, temperature: value })}
-            className="w-full"
+            onValueChange={([value]) =>
+              setLocalSettings({ ...localSettings, temperature: value })
+            }
+            className='w-full'
           />
-          <p className="text-sm text-gray-500">
+          <p className='text-sm text-gray-500'>
             Lower values make output more focused, higher values more creative.
           </p>
         </div>
 
         {/* Max Tokens */}
-        <div className="space-y-2">
-          <Label htmlFor="maxTokens">Max Tokens</Label>
+        <div className='space-y-2'>
+          <Label htmlFor='maxTokens'>Max Tokens</Label>
           <Input
-            id="maxTokens"
-            type="number"
+            id='maxTokens'
+            type='number'
             min={100}
             max={4000}
             value={localSettings.maxTokens}
-            onChange={(e) => setLocalSettings({ ...localSettings, maxTokens: parseInt(e.target.value) })}
+            onChange={e =>
+              setLocalSettings({
+                ...localSettings,
+                maxTokens: parseInt(e.target.value),
+              })
+            }
           />
         </div>
 
         {/* System Prompt */}
-        <div className="space-y-2">
-          <Label htmlFor="systemPrompt">System Prompt</Label>
+        <div className='space-y-2'>
+          <Label htmlFor='systemPrompt'>System Prompt</Label>
           <Textarea
-            id="systemPrompt"
+            id='systemPrompt'
             value={localSettings.systemPrompt}
-            onChange={(e) => setLocalSettings({ ...localSettings, systemPrompt: e.target.value })}
-            className="min-h-[120px]"
+            onChange={e =>
+              setLocalSettings({
+                ...localSettings,
+                systemPrompt: e.target.value,
+              })
+            }
+            className='min-h-[120px]'
             placeholder="System prompt that defines the AI's behavior and role"
           />
           <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => setLocalSettings({ ...localSettings, systemPrompt: DEFAULT_SYSTEM_PROMPT })}
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={() =>
+              setLocalSettings({
+                ...localSettings,
+                systemPrompt: DEFAULT_SYSTEM_PROMPT,
+              })
+            }
           >
             Reset to Default
           </Button>
         </div>
 
         {/* Action Buttons */}
-        <div className="flex gap-2 pt-4">
+        <div className='flex gap-2 pt-4'>
           <Button
             onClick={handleTest}
-            variant="outline"
+            variant='outline'
             disabled={!isValidConfig || testStatus === 'testing'}
-            className="flex items-center gap-2"
+            className='flex items-center gap-2'
           >
-            {testStatus === 'testing' && <div className="w-4 h-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600" />}
-            {testStatus === 'success' && <CheckCircle className="w-4 h-4 text-green-600" />}
-            {testStatus === 'error' && <XCircle className="w-4 h-4 text-red-600" />}
-            {testStatus === 'idle' && <TestTube className="w-4 h-4" />}
+            {testStatus === 'testing' && (
+              <div className='w-4 h-4 animate-spin rounded-full border-2 border-gray-300 border-t-blue-600' />
+            )}
+            {testStatus === 'success' && (
+              <CheckCircle className='w-4 h-4 text-green-600' />
+            )}
+            {testStatus === 'error' && (
+              <XCircle className='w-4 h-4 text-red-600' />
+            )}
+            {testStatus === 'idle' && <TestTube className='w-4 h-4' />}
             Test Connection
           </Button>
-          
+
           <Button
             onClick={handleSave}
             disabled={!isValidConfig}
-            className="flex-1"
+            className='flex-1'
           >
             Save Configuration
           </Button>
@@ -219,14 +294,18 @@ export function AISettingsPanel({ settings, onSettingsChange, onTestConnection, 
 
         {/* Status Messages */}
         {testStatus === 'success' && (
-          <div className="p-3 bg-green-50 border border-green-200 rounded-md">
-            <p className="text-sm text-green-800">✅ Connection successful! AI assistant is ready to use.</p>
+          <div className='p-3 bg-green-50 border border-green-200 rounded-md'>
+            <p className='text-sm text-green-800'>
+              ✅ Connection successful! AI assistant is ready to use.
+            </p>
           </div>
         )}
-        
+
         {testStatus === 'error' && (
-          <div className="p-3 bg-red-50 border border-red-200 rounded-md">
-            <p className="text-sm text-red-800">❌ Connection failed. Please check your API key and try again.</p>
+          <div className='p-3 bg-red-50 border border-red-200 rounded-md'>
+            <p className='text-sm text-red-800'>
+              ❌ Connection failed. Please check your API key and try again.
+            </p>
           </div>
         )}
       </CardContent>

--- a/hooks/use-ai-assistant.ts
+++ b/hooks/use-ai-assistant.ts
@@ -1,6 +1,21 @@
 import { useState, useCallback, useEffect } from 'react';
-import { AISettings, AIMessage, DEFAULT_AI_SETTINGS } from '@/lib/ai-config';
-import { AIService, validateApiKey } from '@/lib/ai-service';
+import {
+  AISettings,
+  AIMessage,
+  AI_PROVIDERS,
+  DEFAULT_AI_SETTINGS,
+} from '@/lib/ai-config';
+import { AIService } from '@/lib/ai-service';
+
+// A provider is usable once a key has been entered when it requires one —
+// format-guessing (e.g. "starts with sk-") rejects valid keys whose format
+// doesn't match the guess (or has since changed), so it isn't used here.
+// The real validator is testConnection, which calls the actual provider API.
+function hasValidConfig(settings: AISettings): boolean {
+  const provider = AI_PROVIDERS.find(p => p.id === settings.provider);
+  if (!provider) return false;
+  return !provider.requiresApiKey || Boolean(settings.apiKey?.trim());
+}
 
 const STORAGE_KEY = 'hex-kex-ai-settings';
 const MESSAGES_STORAGE_KEY = 'hex-kex-ai-messages';
@@ -22,8 +37,8 @@ export function useAIAssistant() {
         const parsed = JSON.parse(savedSettings);
         setSettings(parsed);
 
-        // Check if API key is valid
-        if (parsed.apiKey && validateApiKey(parsed.provider, parsed.apiKey)) {
+        // Check if the provider is usable (key present when required)
+        if (hasValidConfig(parsed)) {
           setIsConfigured(true);
           setAIService(new AIService(parsed));
         }
@@ -60,10 +75,7 @@ export function useAIAssistant() {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(newSettings));
     setSettings(newSettings);
 
-    if (
-      newSettings.apiKey &&
-      validateApiKey(newSettings.provider, newSettings.apiKey)
-    ) {
+    if (hasValidConfig(newSettings)) {
       setIsConfigured(true);
       setAIService(new AIService(newSettings));
     } else {


### PR DESCRIPTION
## Summary
- Both the **Test Connection** and **Save Configuration** buttons in the AI settings panel (`components/ai-settings-panel.tsx`) were gated on `validateApiKey()`, which guesses each provider's key format by a hardcoded prefix (`sk-`, `gsk_`, `mist-`, etc.). Any key that didn't match — including every real Mistral key, which has no `mist-` prefix — left both buttons disabled forever with no explanation. This is exactly the reported bug: "When I add [an] API key I can't test connection or even press save."
- The same guess also gated `isConfigured`/`AIService` creation one layer deeper, in `hooks/use-ai-assistant.ts`'s `saveSettings` and mount-load effect — so even a key that "saved" without error could silently leave the app thinking it's unconfigured. It also meant **Local Ollama** (which needs no key at all) was never marked configured, since its cleared `apiKey` failed the same truthy-and-format check.
- Replaced the format-guessing with a simple presence check (a key was typed, when one's required) in both places. **Test Connection** is already the real validator, since it calls the actual provider API — re-guessing the format client-side was redundant at best, and actively wrong for Mistral.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run` — 52/52 passing
- [x] Verified in a real browser: selected Mistral AI, typed a realistic key without the old guessed `mist-` prefix, and confirmed both Test Connection and Save Configuration become clickable immediately (previously stayed disabled forever)
- [x] Confirmed Save now correctly marks the panel "Configured" for that key


---
_Generated by [Claude Code](https://claude.ai/code/session_014DLB9LkuQiDdeG8phXB95q)_