### PR TITLE
Fix broken/decommissioned AI model IDs and Monaco source-map 404s

### DIFF
--- a/app/api/ai/stream/route.ts
+++ b/app/api/ai/stream/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
       provider = 'openai';
       apiKey = openaiApiKey;
       endpoint = 'https://api.openai.com/v1/chat/completions';
-      model = 'gpt-3.5-turbo'; // Fast model
+      model = 'gpt-4o-mini'; // Fast model
     }
 
     if (!apiKey) {

--- a/components/ai-chat-clean.tsx
+++ b/components/ai-chat-clean.tsx
@@ -145,7 +145,7 @@ export function AIChat({
       onSettingsChange({
         ...settings,
         provider: providerId,
-        model: provider.models[0] || 'gpt-3.5-turbo'
+        model: provider.models[0] || 'gpt-4o-mini'
       });
       setShowProviderConfig(provider.requiresApiKey && !settings.apiKey);
     }

--- a/components/ai-chat.tsx
+++ b/components/ai-chat.tsx
@@ -164,7 +164,7 @@ export function AIChat({
       onSettingsChange({
         ...settings,
         provider: providerId,
-        model: provider.models[0] || 'gpt-3.5-turbo'
+        model: provider.models[0] || 'gpt-4o-mini'
       });
       setShowProviderConfig(provider.requiresApiKey && !settings?.apiKey);
     }
@@ -498,7 +498,7 @@ export function AIChat({
               onClick={() => setShowModelDropdown(!showModelDropdown)}
               className="bg-gray-800 border-gray-600 hover:bg-gray-700 text-xs gap-1"
             >
-              <span className="max-w-24 truncate">{settings?.model || 'gpt-3.5-turbo'}</span>
+              <span className="max-w-24 truncate">{settings?.model || 'gpt-4o-mini'}</span>
               <ChevronDown className="w-3 h-3" />
             </Button>
             

--- a/components/ai-settings-sidebar.tsx
+++ b/components/ai-settings-sidebar.tsx
@@ -46,7 +46,7 @@ export default function AISettingsSidebar({
       onSettingsChange({
         ...settings,
         provider: providerId,
-        model: provider.models[0] || 'gpt-3.5-turbo',
+        model: provider.models[0] || 'gpt-4o-mini',
         apiKey: settings?.apiKey || ''
       });
     }

--- a/components/byok-ai-settings.tsx
+++ b/components/byok-ai-settings.tsx
@@ -73,7 +73,7 @@ export default function BYOKAISettings({
             'anthropic-version': '2023-06-01'
           };
           testBody = {
-            model: 'claude-3-haiku-20240307',
+            model: 'claude-haiku-4-5-20251001',
             max_tokens: 10,
             messages: [{ role: 'user', content: 'test' }]
           };
@@ -112,21 +112,21 @@ export default function BYOKAISettings({
       case 'openai':
         return {
           name: 'OpenAI',
-          description: 'GPT-4, GPT-3.5-turbo models',
+          description: 'GPT-4o and GPT-4.1 models',
           keyFormat: 'sk-...',
           website: 'https://platform.openai.com/api-keys'
         };
       case 'anthropic':
         return {
           name: 'Anthropic',
-          description: 'Claude 3 models (Opus, Sonnet, Haiku)',
+          description: 'Claude models (Sonnet 5, Opus 4.8, Haiku 4.5)',
           keyFormat: 'sk-ant-...',
           website: 'https://console.anthropic.com/'
         };
       case 'groq':
         return {
           name: 'Groq',
-          description: 'Fast inference for Llama, Mixtral models',
+          description: 'Fast inference for Llama and GPT-OSS models',
           keyFormat: 'gsk_...',
           website: 'https://console.groq.com/keys'
         };
@@ -174,8 +174,8 @@ export default function BYOKAISettings({
                 <SelectValue placeholder="Select AI provider" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="openai">OpenAI (GPT-4, GPT-3.5)</SelectItem>
-                <SelectItem value="anthropic">Anthropic (Claude 3)</SelectItem>
+                <SelectItem value="openai">OpenAI (GPT-4o, GPT-4.1)</SelectItem>
+                <SelectItem value="anthropic">Anthropic (Claude 5/4.8)</SelectItem>
                 <SelectItem value="groq">Groq (Fast Inference)</SelectItem>
               </SelectContent>
             </Select>
@@ -239,26 +239,23 @@ export default function BYOKAISettings({
                   <>
                     <SelectItem value="gpt-4o">GPT-4o (Latest)</SelectItem>
                     <SelectItem value="gpt-4o-mini">GPT-4o Mini (Fast)</SelectItem>
-                    <SelectItem value="gpt-4-turbo">GPT-4 Turbo</SelectItem>
-                    <SelectItem value="gpt-3.5-turbo">GPT-3.5 Turbo</SelectItem>
+                    <SelectItem value="gpt-4.1">GPT-4.1</SelectItem>
+                    <SelectItem value="gpt-4.1-mini">GPT-4.1 Mini</SelectItem>
                   </>
                 )}
                 {settings.provider === 'anthropic' && (
                   <>
-                    <SelectItem value="claude-3-5-sonnet-20241022">Claude 3.5 Sonnet (Latest)</SelectItem>
-                    <SelectItem value="claude-3-opus-20240229">Claude 3 Opus</SelectItem>
-                    <SelectItem value="claude-3-sonnet-20240229">Claude 3 Sonnet</SelectItem>
-                    <SelectItem value="claude-3-haiku-20240307">Claude 3 Haiku</SelectItem>
+                    <SelectItem value="claude-sonnet-5">Claude Sonnet 5 (Latest)</SelectItem>
+                    <SelectItem value="claude-opus-4-8">Claude Opus 4.8</SelectItem>
+                    <SelectItem value="claude-haiku-4-5-20251001">Claude Haiku 4.5</SelectItem>
                   </>
                 )}
                 {settings.provider === 'groq' && (
                   <>
-                    <SelectItem value="llama-3.1-405b-reasoning">Llama 3.1 405B (Best)</SelectItem>
                     <SelectItem value="llama-3.1-8b-instant">Llama 3.1 8B (Fast)</SelectItem>
-                    <SelectItem value="llama-3.2-90b-text-preview">Llama 3.2 90B (Preview)</SelectItem>
-                    <SelectItem value="mixtral-8x7b-32768">Mixtral 8x7B</SelectItem>
-                    <SelectItem value="gemma2-9b-it">Gemma 2 9B</SelectItem>
-                    <SelectItem value="mistral-7b-instruct">Mistral 7B</SelectItem>
+                    <SelectItem value="llama-3.3-70b-versatile">Llama 3.3 70B</SelectItem>
+                    <SelectItem value="openai/gpt-oss-120b">GPT-OSS 120B</SelectItem>
+                    <SelectItem value="openai/gpt-oss-20b">GPT-OSS 20B</SelectItem>
                   </>
                 )}
               </SelectContent>

--- a/lib/ai-config.ts
+++ b/lib/ai-config.ts
@@ -26,14 +26,14 @@ export const AI_PROVIDERS: AIProvider[] = [
     name: "OpenAI",
     id: "openai",
     requiresApiKey: true,
-    models: ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo", "gpt-3.5-turbo"],
+    models: ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "gpt-4.1-mini"],
     endpoint: "https://api.openai.com/v1/chat/completions"
   },
   {
     name: "Anthropic Claude",
-    id: "anthropic", 
+    id: "anthropic",
     requiresApiKey: true,
-    models: ["claude-3-5-sonnet", "claude-3-opus", "claude-3-sonnet", "claude-3-haiku"],
+    models: ["claude-sonnet-5", "claude-opus-4-8", "claude-haiku-4-5-20251001"],
     endpoint: "https://api.anthropic.com/v1/messages"
   },
   {
@@ -41,13 +41,10 @@ export const AI_PROVIDERS: AIProvider[] = [
     id: "groq",
     requiresApiKey: true,
     models: [
-      "llama-3.1-405b-reasoning",  // Llama 3.1 405B - Best reasoning
-      "llama-3.1-8b-instant",      // Llama 3.1 8B - Fast and cheap
-      "llama-3.2-90b-text-preview", // Llama 3.2 90B - Latest preview
-      "mixtral-8x7b-32768",        // Mixtral 8x7B - Good performance
-      "gemma2-9b-it",              // Gemma 2 9B - Google's model
-      "mistral-7b-instruct",       // Mistral 7B - Good for instruction
-      "whisper-large-v3"           // Groq Whisper - Voice transcription
+      "llama-3.1-8b-instant",       // Llama 3.1 8B - Fast and cheap, confirmed working
+      "llama-3.3-70b-versatile",    // Llama 3.3 70B - Strong general model
+      "openai/gpt-oss-120b",        // GPT-OSS 120B - Groq's recommended migration target
+      "openai/gpt-oss-20b"          // GPT-OSS 20B - Fast, replaces retired Mixtral/Gemma models
     ],
     endpoint: "https://api.groq.com/openai/v1/chat/completions"
   },
@@ -55,14 +52,14 @@ export const AI_PROVIDERS: AIProvider[] = [
     name: "Google Gemini",
     id: "google",
     requiresApiKey: true,
-    models: ["gemini-1.5-pro", "gemini-1.5-flash", "gemini-pro"],
+    models: ["gemini-pro-latest", "gemini-flash-latest", "gemini-3.5-flash-lite"],
     endpoint: "https://generativelanguage.googleapis.com/v1beta/models"
   },
   {
     name: "Mistral AI",
     id: "mistral",
     requiresApiKey: true,
-    models: ["mistral-large", "mistral-medium", "mistral-small"],
+    models: ["mistral-large-latest", "mistral-medium-latest", "mistral-small-latest"],
     endpoint: "https://api.mistral.ai/v1/chat/completions"
   },
   {

--- a/scripts/copy-monaco.cjs
+++ b/scripts/copy-monaco.cjs
@@ -21,4 +21,28 @@ if (!fs.existsSync(src)) {
 
 fs.rmSync(dest, { recursive: true, force: true });
 fs.cpSync(src, dest, { recursive: true });
-console.log(`✅ Copied Monaco Editor static build to ${path.relative(process.cwd(), dest)}`);
+
+// The "min" build's .js files reference maps under a sibling "min-maps"
+// directory we don't copy (it's tens of MB and only useful for debugging
+// Monaco's own source, not our app). Left in place, browsers request those
+// .map URLs and get 404s in the console. Strip the trailing
+// `//# sourceMappingURL=...` comment so nothing is requested.
+const sourceMapCommentRe = /\n\/\/# sourceMappingURL=.*\.map\s*$/;
+let strippedCount = 0;
+(function stripSourceMaps(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      stripSourceMaps(entryPath);
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      const contents = fs.readFileSync(entryPath, 'utf8');
+      const stripped = contents.replace(sourceMapCommentRe, '');
+      if (stripped !== contents) {
+        fs.writeFileSync(entryPath, stripped);
+        strippedCount++;
+      }
+    }
+  }
+})(dest);
+
+console.log(`✅ Copied Monaco Editor static build to ${path.relative(process.cwd(), dest)} (stripped sourceMappingURL from ${strippedCount} files)`);


### PR DESCRIPTION
Groq deprecated mixtral-8x7b-32768, gemma2-9b-it, and the old 405b/90b preview IDs; mistral-7b-instruct was never a valid Groq model. Replace with the currently active Groq lineup (llama-3.1-8b-instant, llama-3.3-70b-versatile, openai/gpt-oss-120b/20b). Also refresh the stale OpenAI (gpt-3.5-turbo/gpt-4-turbo), Anthropic (Claude 3), Google Gemini (gemini-1.5-*), and Mistral (missing -latest alias) model lists to their current provider-verified equivalents, in ai-config.ts and the BYOK settings UI.

Also stop shipping broken sourceMappingURL references in the self-hosted Monaco build: copy-monaco.cjs only copies the "min" build, not "min-maps", so the browser was requesting nonexistent loader.js.map/editor.main.js.map/workerMain.js.map and logging 404s. Strip the sourceMappingURL comments after copying instead.